### PR TITLE
Align traits associated types

### DIFF
--- a/src/backends/bls12381_arkworks/scalar.rs
+++ b/src/backends/bls12381_arkworks/scalar.rs
@@ -25,6 +25,7 @@ pub struct Scalar(pub(super) Fr);
 
 impl ScalarField for Scalar {
     const SCALAR_SIZE: usize = bls12381::SCALAR_SIZE;
+    type Serialized = [u8; Self::SCALAR_SIZE];
 
     fn one() -> Self {
         Self(Fr::one())
@@ -39,7 +40,7 @@ impl ScalarField for Scalar {
         Self(<Fr as PrimeField>::from_be_bytes_mod_order(bytes))
     }
 
-    fn to_bytes_be(self) -> Result<[u8; Self::SCALAR_SIZE], BackendsError> {
+    fn to_bytes_be(self) -> Result<Self::Serialized, BackendsError> {
         let mut writer = [0; Self::SCALAR_SIZE];
         CanonicalSerialize::serialize_compressed(&self.0, &mut writer[..])
             .map_err(|_| BackendsError::ScalarSerialize)?;

--- a/src/backends/bls12381_blstrs/g1.rs
+++ b/src/backends/bls12381_blstrs/g1.rs
@@ -1,7 +1,9 @@
 use super::super::error::BackendsError;
 use super::super::error::BlsError;
+use super::bls12381;
 use super::scalar::Scalar;
-use crate::curves::bls12381;
+use super::Serializer;
+
 use crate::traits::Affine;
 use crate::traits::Group;
 use crate::traits::PairingCurve;
@@ -28,7 +30,9 @@ impl Affine for G1Affine {
     }
 
     fn serialize(&self) -> Result<Self::Serialized, BackendsError> {
-        Ok(self.0.to_compressed())
+        let output = Serializer::serialize(self)?;
+
+        Ok(output)
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, BackendsError> {
@@ -66,7 +70,9 @@ impl Projective for G1Projective {
     }
 
     fn serialize(&self) -> Result<Self::Serialized, BackendsError> {
-        Ok(self.0.to_compressed())
+        let output = Serializer::serialize(self)?;
+
+        Ok(output)
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, BackendsError> {
@@ -130,6 +136,24 @@ impl PairingCurve for bls12381::G1 {
         }
 
         Ok(())
+    }
+}
+
+impl Serializer for G1Affine {
+    type Output = <G1Affine as Affine>::Serialized;
+
+    #[inline(always)]
+    fn serialize(&self) -> Result<Self::Output, std::convert::Infallible> {
+        Ok(self.0.to_compressed())
+    }
+}
+
+impl Serializer for G1Projective {
+    type Output = <G1Projective as Projective>::Serialized;
+
+    #[inline(always)]
+    fn serialize(&self) -> Result<Self::Output, std::convert::Infallible> {
+        Ok(self.0.to_compressed())
     }
 }
 

--- a/src/backends/bls12381_blstrs/g2.rs
+++ b/src/backends/bls12381_blstrs/g2.rs
@@ -1,7 +1,9 @@
 use super::super::error::BackendsError;
 use super::super::error::BlsError;
+use super::bls12381;
 use super::scalar::Scalar;
-use crate::curves::bls12381;
+use super::Serializer;
+
 use crate::traits::Affine;
 use crate::traits::Group;
 use crate::traits::PairingCurve;
@@ -28,7 +30,9 @@ impl Affine for G2Affine {
     }
 
     fn serialize(&self) -> Result<Self::Serialized, BackendsError> {
-        Ok(self.0.to_compressed())
+        let output = Serializer::serialize(self)?;
+
+        Ok(output)
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, BackendsError> {
@@ -66,7 +70,9 @@ impl Projective for G2Projective {
     }
 
     fn serialize(&self) -> Result<Self::Serialized, BackendsError> {
-        Ok(self.0.to_compressed())
+        let output = Serializer::serialize(self)?;
+
+        Ok(output)
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, BackendsError> {
@@ -124,6 +130,24 @@ impl PairingCurve for bls12381::G2 {
         }
 
         Ok(())
+    }
+}
+
+impl Serializer for G2Affine {
+    type Output = <G2Affine as Affine>::Serialized;
+
+    #[inline(always)]
+    fn serialize(&self) -> Result<Self::Output, std::convert::Infallible> {
+        Ok(self.0.to_compressed())
+    }
+}
+
+impl Serializer for G2Projective {
+    type Output = <G2Projective as Projective>::Serialized;
+
+    #[inline(always)]
+    fn serialize(&self) -> Result<Self::Output, std::convert::Infallible> {
+        Ok(self.0.to_compressed())
     }
 }
 

--- a/src/backends/bls12381_blstrs/scalar.rs
+++ b/src/backends/bls12381_blstrs/scalar.rs
@@ -1,5 +1,6 @@
 use super::super::error::BackendsError;
-use crate::curves::bls12381;
+use super::bls12381;
+use super::Serializer;
 use crate::traits::ScalarField;
 
 use std::fmt::Display;
@@ -19,6 +20,7 @@ pub struct Scalar(pub(super) blstrs::Scalar);
 
 impl ScalarField for Scalar {
     const SCALAR_SIZE: usize = bls12381::SCALAR_SIZE;
+    type Serialized = [u8; Self::SCALAR_SIZE];
 
     fn one() -> Self {
         Self(blstrs::Scalar::ONE)
@@ -43,7 +45,7 @@ impl ScalarField for Scalar {
         }
     }
 
-    fn to_bytes_be(self) -> Result<[u8; Self::SCALAR_SIZE], BackendsError> {
+    fn to_bytes_be(self) -> Result<Self::Serialized, BackendsError> {
         Ok(self.0.to_bytes_be())
     }
 
@@ -80,6 +82,15 @@ impl ScalarField for Scalar {
 
     fn zero() -> Self {
         Self(blstrs::Scalar::ZERO)
+    }
+}
+
+impl Serializer for Scalar {
+    type Output = <Scalar as ScalarField>::Serialized;
+
+    #[inline(always)]
+    fn serialize(&self) -> Result<Self::Output, std::convert::Infallible> {
+        Ok(self.0.to_bytes_be())
     }
 }
 

--- a/src/backends/bn254_arkworks/scalar.rs
+++ b/src/backends/bn254_arkworks/scalar.rs
@@ -25,6 +25,7 @@ pub struct Scalar(pub(super) Fr);
 
 impl ScalarField for Scalar {
     const SCALAR_SIZE: usize = bn254::SCALAR_SIZE;
+    type Serialized = [u8; Self::SCALAR_SIZE];
 
     fn one() -> Self {
         Self(Fr::one())
@@ -39,7 +40,7 @@ impl ScalarField for Scalar {
         Self(<Fr as PrimeField>::from_be_bytes_mod_order(bytes))
     }
 
-    fn to_bytes_be(self) -> Result<[u8; Self::SCALAR_SIZE], BackendsError> {
+    fn to_bytes_be(self) -> Result<Self::Serialized, BackendsError> {
         let mut bytes = [0; Self::SCALAR_SIZE];
         CanonicalSerialize::serialize_compressed(&self.0, &mut bytes[..])
             .map_err(|_| BackendsError::ScalarSerialize)?;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -8,7 +8,24 @@ mod bls12381_blstrs {
     mod scalar;
 
     use crate::curves::bls12381;
+    use std::convert::Infallible;
+
     super::impl_groups!(bls12381);
+
+    /// Infallible serializer for blstrs scalar and points
+    /// Used internally to simplify public traits bounds.
+    trait Serializer {
+        type Output;
+
+        fn serialize(&self) -> Result<Self::Output, Infallible>;
+    }
+
+    impl From<Infallible> for super::error::BackendsError {
+        #[inline]
+        fn from(infallible: Infallible) -> super::error::BackendsError {
+            match infallible {}
+        }
+    }
 }
 
 #[cfg(feature = "bls12381_arkworks")]

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,6 +1,6 @@
 // TODO: add error asserts
 
-//! This module includes full list of supported drand schemes,
+//! This module includes full list of supported Drand v2 schemes,
 //! to execute tests the backends need to be specified, valid options are:
 //!    cargo test --features  bls12381_blstrs,bn254_arkworks
 //! or
@@ -52,8 +52,8 @@ mod tests {
         let private = S::Scalar::random();
         let public = S::sk_to_pk(&private);
         let msg = S::Scalar::random().to_bytes_be().unwrap();
-        let sig = schnorr::sign::<S>(&private, &msg).unwrap();
-        assert!(schnorr::verify::<S>(&public, &msg, &sig).is_ok())
+        let sig = schnorr::sign::<S>(&private, msg.as_ref()).unwrap();
+        assert!(schnorr::verify::<S>(&public, msg.as_ref(), &sig).is_ok())
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -52,13 +52,16 @@ pub trait ScalarField:
     + for<'a> AddAssign<&'a Self>
 {
     const SCALAR_SIZE: usize;
+    /// Serialized scalar output.
+    /// Configured for all implementors as array [0u8; <curve>::<scalar-size>]
+    type Serialized: AsRef<[u8]> + Into<Vec<u8>>;
 
     fn zero() -> Self;
     fn one() -> Self;
     fn random() -> Self;
     fn invert(&self) -> Result<Self, BackendsError>;
     fn from_u64(val: u64) -> Self;
-    fn to_bytes_be(self) -> Result<[u8; 32], BackendsError>;
+    fn to_bytes_be(self) -> Result<Self::Serialized, BackendsError>;
     fn from_bytes_be(bytes: &[u8]) -> Result<Self, BackendsError>;
     fn from_be_bytes_mod_order(bytes: &[u8]) -> Self;
     fn set_bytes(public: &[u8], r: &[u8], msg: &[u8]) -> Self {
@@ -72,6 +75,8 @@ pub trait ScalarField:
 }
 
 pub trait Affine: Default + Sync + Send + Sized + PartialEq + Debug + Display {
+    /// Serialized point output.
+    /// Configured for all implementors as array [0u8; <curve>::<group>::<point-size>]
     type Serialized: AsRef<[u8]> + Into<Vec<u8>>;
 
     fn generator() -> Self;
@@ -89,6 +94,8 @@ pub trait Affine: Default + Sync + Send + Sized + PartialEq + Debug + Display {
 }
 
 pub trait Projective: Sized + Debug + PartialEq + for<'a> AddAssign<&'a Self> {
+    /// Serialized point output.
+    /// Configured for all implementors as array [0u8; <curve>::<group>::<point-size>]
     type Serialized: AsRef<[u8]> + Into<Vec<u8>>;
 
     fn identity() -> Self;


### PR DESCRIPTION
Introduce Self::serialized type for scalar and points traits; use infallible for blstrs backend.